### PR TITLE
Added is_dashcam to MetaDataItem. Bug fix

### DIFF
--- a/src/data/MetaDataItem.py
+++ b/src/data/MetaDataItem.py
@@ -5,7 +5,7 @@ import os
 
 
 class MetaDataItem:
-    def __init__(self, title, url, download_src, id=None, collision_type=None, description=None, location=None, accident_index=None, tags={}):
+    def __init__(self, title, url, download_src, id=None, collision_type=None, description=None, location=None, accident_index=None, is_dashcam=None, tags={}):
         self.id = id
         self.title = title
         self.url = url
@@ -14,6 +14,7 @@ class MetaDataItem:
         self.location = location
         self.download_src = download_src
         self.accident_index = accident_index
+        self.is_dashcam = is_dashcam
 
         if tags is None:
             self.tags = {}
@@ -35,6 +36,7 @@ class MetaDataItem:
             'description' : str,
             'location' : str,
             'accident_index': int,
+            'is_dashcam': bool,
             'tags': dict
         }
       
@@ -50,6 +52,7 @@ class MetaDataItem:
             'description': self.description,
             'location': self.location,
             'accident_index': self.accident_index,
+            'is_dashcam': self.is_dashcam,
             'tags': self.tags
         }
 

--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -8,13 +8,13 @@ Navigation:
     space: pause/unpause
 
 Tagging:
-    m: Tag the current location as accident location
-    n: Tag the video as not a dashcam video
-    b: Remove tagging
+    m: Mark current location as accident location
+    n: Not a dashcam video
+        NOTE: by default, all videos will be dashcam
+    u: untag (Remove tags)
 
 Note:
     By default, video are assumed to be dashcam video
-    For now, if it actually is dashcam video is ignored. There is no field in MetaDataItem
 
 """
 from src.gui_tool.gui_managers import VideoPlayerGUIManager
@@ -24,6 +24,7 @@ from src.data.MetaDataItem import MetaDataItem
 def tag_file(file_loc, mdi:MetaDataItem):
     gui = VideoPlayerGUIManager(file_loc)
     res = gui.start()
-    mdi.location = res.accident_frame_number
+    mdi.accident_index = res.accident_frame_number
+    mdi.is_dashcam = res.is_dashcam
     return mdi
 

--- a/src/gui_tool/gui_managers.py
+++ b/src/gui_tool/gui_managers.py
@@ -153,7 +153,7 @@ class VideoPlayerGUIManager(object):
                 self.vcm.shift_frame_index(10)
             elif received_key == ord(" "):
                 cv2.setTrackbarPos(self.PAUSE_BUTTON_NAME, self.WINDOW_NAME, not self.vcm.get_paused())
-            elif received_key == ord("b"):
+            elif received_key == ord("u"):
                 self.result.unmark()
                 mark_changed = True
             elif received_key == ord("n"):
@@ -169,6 +169,5 @@ class VideoPlayerGUIManager(object):
     def cleanup(self):
         self.vcm.release()
         cv2.destroyAllWindows()
-
 
 


### PR DESCRIPTION
Note: by default, all videos put into the tagger are dashcam unless marked otherwise