### PR TITLE
Make splitter return videoItems instead of metadataItems

### DIFF
--- a/custom_configs/review_database_videos.yml
+++ b/custom_configs/review_database_videos.yml
@@ -1,0 +1,23 @@
+dataSources:
+  - executor: FirebaseSource
+processingStages:
+  - executor: Filterer
+    config:
+      filter_str: "tags['state'] != 'processed'"
+  - executor: Filterer
+    config:
+      filter_str: 'is_cancelled != 1'
+  - executor: AutoLabeler
+    config:
+      key: "state"
+      val: "in-progress"
+  - executor: FirebaseUpdater
+  - executor: UniversalDownloader
+  - executor: Printer
+  - executor: Splitter
+  - executor: Labeler
+  - executor: AutoLabeler
+  - executor: FirebaseUpdater
+  - executor: Printer
+    config:
+      msg: "labelling and video uploaded"

--- a/src/data/MetaDataItem.py
+++ b/src/data/MetaDataItem.py
@@ -27,7 +27,7 @@ class MetaDataItem:
         self.end_i = kwargs.get("end_i", None)
 
     def __repr__(self) -> str:
-        return self.to_json_str()
+        return f"Metadata {self.id}:\n\n" + self.to_json_str()
 
     # Returns lists of attributes and their types. Types should ideally be default constructable.
     @staticmethod
@@ -40,6 +40,7 @@ class MetaDataItem:
             'description' : str,
             'location' : str,
             'tags': dict,
+            'id': str,
             'is_cancelled': bool,
             'is_split_url': bool,
             'bb_fields': dict,
@@ -58,6 +59,7 @@ class MetaDataItem:
             'collision_type': self.collision_type,
             'description': self.description,
             'location': self.location,
+            'id': self.id,
             'is_cancelled': self.is_cancelled,
             'is_split_url': self.is_split_url,
             'tags': self.tags,

--- a/src/data/VideoItem.py
+++ b/src/data/VideoItem.py
@@ -20,4 +20,11 @@ class VideoItem:
     def save_and_close(self, **kwargs):
         file_path = kwargs.get('file_path', self.file_path)
 
+    def to_json(self):
+        return {
+            "filepath": self.filepath,
+            "metadata": self.metadata,
+        }
 
+    def __repr__(self) -> str:
+        return str(self.to_json())

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -20,9 +20,9 @@ def get_firebase_access():
         return ReadOnlyFirebaseAccessor()
 
 def get_database(database_config: DatabaseConfigOption):
-    if database_config is DatabaseConfigOption.firebase:
-        database_access = get_firebase_access()
-    else:
+    if database_config is DatabaseConfigOption.local:
         database_access = LocalStorageAccessor()
+    else:
+        database_access = get_firebase_access()
 
     return database_access

--- a/src/downloader/ImgurDownloader.py
+++ b/src/downloader/ImgurDownloader.py
@@ -1,6 +1,7 @@
 from ..downloader.iDownloader import iDownloader, DownloadException
 from ..data.VideoItem import VideoItem
 from ..data.MetaDataItem import MetaDataItem
+from ..signals.StopSignal import StopSignal
 from imgur_downloader import ImgurDownloader as imgur
 import os, re, shutil
 
@@ -13,10 +14,14 @@ class ImgurDownloader(iDownloader):
         filename = self.video_storage.get_file_name(md_item)
 
         print(f"downloading file {filename}")
-        downloader = imgur(link,
-                           dir_download=pathname,
-                           file_name=filename)
-        files, idx = downloader.save_images()
+        try:
+            downloader = imgur(link,
+                               dir_download=pathname,
+                               file_name=filename)
+            files, idx = downloader.save_images()
+        except Exception as e:
+            print(f"Error in downloading: {e}, stopping")
+            raise DownloadException("Could not download from{link}")
         print(f"downloaded {files}")
 
         # album downloaded, extract video from album

--- a/src/executor/Printer.py
+++ b/src/executor/Printer.py
@@ -8,8 +8,7 @@ class Printer(iExecutor):
 
     def run(self, item):
         if item is not None:
-            metadata = iExecutor.get_metadata(item)
-            print(f"printer loaded, item {metadata}, message: {self.msg}")
+            print(f"printer loaded, item {item}, message: {self.msg}")
         else:
             print(f"printer loaded, message: {self.msg}")
         return item

--- a/src/executor/Splitter.py
+++ b/src/executor/Splitter.py
@@ -4,5 +4,8 @@ from .iExecutor import iExecutor
 
 class Splitter(iExecutor):
     def run(self, item: VideoItem):
-        items = split_file(item.filepath, item.metadata)
+        items = map(
+            lambda mdi: VideoItem(mdi,filepath=item.filepath),
+            split_file(item.filepath, item.metadata)
+        )
         return items

--- a/src/gui_tool/gui/bb_gui.py
+++ b/src/gui_tool/gui/bb_gui.py
@@ -41,7 +41,7 @@ SELECTION_MODE_INSTRUCTIONS = [
 ]
 
 BB_CLASS_DEFAULT_OPTIONS = [
-    "car", "truck", "motorcycle", "van", "pedestrian"
+    "car", "truck", "motorcycle", "van", "pedestrian", "bus"
 ]
 
 class BBGUIManager(VideoPlayerGUIManager):

--- a/test/crawler/testICrawler.py
+++ b/test/crawler/testICrawler.py
@@ -58,6 +58,7 @@ class TestICrawler(unittest.TestCase):
         # Get exact copy of the metadata item that was published
         copy_metadata = self.crawler.next_downloadable()
 
+        copy_metadata.id = metadata.id #need to do this because otherwise cant compare
         self.assertEqual(metadata.to_json(), copy_metadata.to_json())
 
 


### PR DESCRIPTION
this is necessary to keep track of the file location of videos
also allow printer to print videoItems so that we can see filepaths of videos