### PR TITLE
added new ui to set custom tags

### DIFF
--- a/src/data/MetaDataItem.py
+++ b/src/data/MetaDataItem.py
@@ -14,6 +14,7 @@ class MetaDataItem:
         self.description = kwargs.get("description", None)
         self.location = kwargs.get("location", None)
         self.tags = kwargs.get("tags", {})
+        self.enum_tags = kwargs.get("enum_tags", [])
         self.is_cancelled = kwargs.get("is_cancelled", False)
         self.is_split_url = kwargs.get("is_split_url", False)
 
@@ -36,11 +37,12 @@ class MetaDataItem:
             'title': str,
             'url' : str,
             'download_src': str,
-            'collision_type' : str,
-            'description' : str,
-            'location' : str,
+            'collision_type': str,
+            'description': str,
+            'location': str,
             'tags': dict,
             'id': str,
+            'enum_tags': list,
             'is_cancelled': bool,
             'is_split_url': bool,
             'bb_fields': dict,
@@ -63,6 +65,7 @@ class MetaDataItem:
             'is_cancelled': self.is_cancelled,
             'is_split_url': self.is_split_url,
             'tags': self.tags,
+            'enum_tags': self.enum_tags,
             'bb_fields': self.bb_fields.to_json(),
             'start_i': self.start_i,
             'end_i': self.end_i,

--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -27,10 +27,12 @@ def tag_file(file_loc, mdi:MetaDataItem):
                 bbox_fields=mdi.bb_fields,
                 start_index=mdi.start_i,
                 end_index=mdi.end_i)
+            context.enum_tags = mdi.enum_tags
             gui = BBGUIManager(context)
             gui.start()
 
             mdi.bb_fields = context.get_bbox_fields()
+            mdi.enum_tags = context.enum_tags
 
             for key, val in context.additional_tags:
                 mdi.add_tag(key, val)
@@ -52,8 +54,11 @@ def split_file(file_loc, mdi:MetaDataItem):
     while True:
         try:
             context = GUIContext(file_loc)
+            context.enum_tags = mdi.enum_tags
             gui = SPGUIManager(context)
             rs = gui.start()
+
+            mdi.enum_tags = context.enum_tags
 
             if len(rs) == 0:
                 raise CancelSignal("No sections of the video are of interest")

--- a/src/gui_tool/gui/bb_gui.py
+++ b/src/gui_tool/gui/bb_gui.py
@@ -2,6 +2,7 @@ from src.gui_tool.utils.key_mapper import KeyMapper
 from .context import GUIContext
 from .bb.BoundingBoxManager import BoundingBoxManager
 from .tinker_subuis.additional_tags import AdditionalTagWindow
+from .tinker_subuis.multiselect_popup import MultiSelectPopup
 from .tinker_subuis.text_popup import TextPopup
 from .tinker_subuis.select_popup import SelectPopup
 import cv2
@@ -37,7 +38,8 @@ SELECTION_MODE_INSTRUCTIONS = [
         "Toggle whether it is a dashcam video",
         "NOTE: by default, all videos will be dashcam",
         "Pressing n the first time will mark the video as not dashcam"],
-    ["t", "Opens window for user customizable tags"],
+    ["t", "Opens window for user customizable key-value tags"],
+    ["v", "Opens window for user customizable enum tags"],
 ]
 
 BB_CLASS_DEFAULT_OPTIONS = [
@@ -92,12 +94,23 @@ class InternaSelectionMode(InternalMode):
             tags = window.get_user_tags()
             par.context.set_additional_tags(tags)
             self.log("Additional tags set")
+        elif key_mapper.consume("v"):
+            window = MultiSelectPopup("Select custom enum tags", "video_enum_tags", self.par.context.enum_tags)
+            enum_tags = window.run()
+            if enum_tags is not None:
+                self.log("Updated from {0}".format(self.par.context.enum_tags))
+                self.log("Now: {0}".format(enum_tags))
+                self.par.context.enum_tags = enum_tags
+                self.log("Remember to commit any new tags!")
+            else:
+                self.log("Enum tag update cancelled")
     def get_state_message(self):
         return [
             "Selection Mode",
             "{0} Selected".format(self.par.bbm.get_n_selected()),
             "{0} Total".format(self.par.bbm.get_n_ids()),
-            "Is dashcam" if self.par.context.is_dashcam else "Not dashcam"
+            "Is dashcam" if self.par.context.is_dashcam else "Not dashcam",
+            "{0} enum tags set".format(len(self.par.context.enum_tags))
         ]
 
 class InternalBBoxMode(InternalMode):

--- a/src/gui_tool/gui/context.py
+++ b/src/gui_tool/gui/context.py
@@ -10,6 +10,7 @@ class GUIContext(object):
         self.file_width = self.vcm.get_width()
 
         self.is_dashcam = True
+        self.enum_tags = []
 
     def mark_is_dashcam(self, is_dashcam: bool):
         self.marked = True

--- a/src/gui_tool/gui/sp_gui.py
+++ b/src/gui_tool/gui/sp_gui.py
@@ -3,6 +3,7 @@ from ..utils.key_mapper import KeyMapper
 from .general_gui import VideoPlayerGUIManager
 from .gui_mode import InternalMode
 import cv2
+from .tinker_subuis.multiselect_popup import MultiSelectPopup
 
 SP_MODE_INSTRUCTIONS = [
     ["x", "Split at the current frame exclusively", "Split is exclusive (current frame is gone)"],
@@ -77,6 +78,16 @@ class SPMode(InternalMode):
                 self.par.vcm.start_from(n_loc)
             else:
                 self.error("Can't jump: No previous split exists")
+        elif key_mapper.consume("v"):
+            window = MultiSelectPopup("Select custom enum tags", "video_enum_tags", self.par.context.enum_tags)
+            enum_tags = window.run()
+            if enum_tags is not None:
+                self.log("Updated from {0}".format(self.par.context.enum_tags))
+                self.log("Now: {0}".format(enum_tags))
+                self.par.context.enum_tags = enum_tags
+                self.log("Remember to commit any new tags!")
+            else:
+                self.log("Enum tag update cancelled")
 
     def get_state_message(self):
         return [

--- a/src/gui_tool/gui/tinker_subuis/multiselect_popup.py
+++ b/src/gui_tool/gui/tinker_subuis/multiselect_popup.py
@@ -1,0 +1,79 @@
+from tkinter import Tk, Frame, Entry, Button, Checkbutton, StringVar
+from tkinter import END
+from .cashe_manager import ListCacheManager
+
+class MultiSelectPopup:
+    def __init__(self, title, cache_name, starting_selected=None, cache_amount=100):
+        self.tags = []
+        self.entries = []
+        self.root = Tk()
+        self.root.title(title)
+        self.root.minsize(width=400, height=1)
+
+        self.options_frame = Frame(self.root)
+        self.button_frame = Frame(self.root)
+
+        self.cm = ListCacheManager(cache_name, cache_amount)
+        options = self.cm.retrieve()
+
+        if starting_selected is None:
+            starting_selected = []
+        for val in starting_selected:
+            if val not in options:
+                options.append(val)
+
+        self.vars = []
+        for val in options:
+            self.__add_option(val, val in starting_selected)
+
+        self.inp_field = Entry(self.button_frame)
+        self.inp_field.config(width=100)
+        self.inp_field.pack()
+
+        self.confirm_button = Button(self.button_frame, text="Confirm", command=self.submit)
+        self.confirm_button.pack()
+        self.cancel_button = Button(self.button_frame, text="Cancel", command=lambda: self.root.destroy())
+        self.cancel_button.pack()
+
+        self.options_frame.pack()
+        self.button_frame.pack()
+        self.inp_field.focus_set()
+
+        self.inp = None
+        self.inp_field.bind('<Return>', lambda event: self.__add_input())
+        self.root.bind('<Escape>', lambda event: self.root.destroy())
+        self.root.after(1, lambda: self.root.focus_force())
+
+    def __add_input(self):
+        text = self.inp_field.get().strip()
+        self.inp_field.delete(0, END)
+        self.inp_field.insert(END, "")
+
+        if text in self.cm.retrieve():
+            return
+
+        self.__add_option(text)
+        self.vars[-1].set(text)
+        self.cm.insert(text)
+        print("{0} inserted into cache".format(text))
+
+    def __add_option(self, text, selected=False):
+        if selected:
+            var = StringVar(value=text)
+        else:
+            var = StringVar(value="")
+        button = Checkbutton(self.options_frame, text=text, var=var, onvalue=text, offvalue="")
+        button.pack()
+        self.vars.append(var)
+
+    def submit(self):
+        self.inp = []
+        for var in self.vars:
+            value = var.get()
+            if value:
+                self.inp.append(value)
+        self.root.destroy()
+
+    def run(self) -> str:
+        self.root.mainloop()
+        return self.inp

--- a/src/gui_tool/gui/tinker_subuis/select_popup.py
+++ b/src/gui_tool/gui/tinker_subuis/select_popup.py
@@ -25,7 +25,7 @@ class SelectPopup:
 
         self.confirm_button = Button(self.frame, text="Confirm", command=self.submit)
         self.confirm_button.grid(row=i//2+2, column=1)
-        self.cancel_button = Button(self.frame, text="Cancel", command=lambda event: self.root.destroy())
+        self.cancel_button = Button(self.frame, text="Cancel", command=lambda: self.root.destroy())
         self.cancel_button.grid(row=i//2+2, column=2)
 
         self.frame.pack()

--- a/src/gui_tool/gui/tinker_subuis/store_video_enum_tags.cache
+++ b/src/gui_tool/gui/tinker_subuis/store_video_enum_tags.cache
@@ -1,0 +1,1 @@
+["NoCollision", "CollisionWithStationaryObject", "CollisionWithAnimal", "MultiCollision", "StationaryCamera", "ManHeldCamera", "LowQualityVideo", "LowVisibility", "PoorLighting"]


### PR DESCRIPTION
Makes it easier to go back to videos we skipped by searching in the database for which one we want to return to. 

This commit includes ["NoCollision", "CollisionWithStationaryObject", "CollisionWithAnimal", "MultiCollision", "StationaryCamera", "ManHeldCamera", "LowQualityVideo", "LowVisibility", "PoorLighting"]

UI allows adding new tags to videos. User should commit src/gui_tool/gui/tinker_subuis/store_video_enum_tags.cache when they add a new custom tag so that everyone else will see it as well

![image](https://user-images.githubusercontent.com/36652220/98453577-fc8d1180-2117-11eb-9e2a-7c45d811fdbd.png)
