### PR TITLE
Massive refactor. Allowed for each section in the split to have their own enum tags

### DIFF
--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -61,6 +61,7 @@ def split_file(file_loc, mdi:MetaDataItem):
             rs = gui.start()
 
             if len(rs) == 0:
+                mdi.enum_tags = gui.mode_handlers[0].sm.get_first_enum_tags()
                 raise CancelSignal("No sections of the video are of interest")
 
             split_vid = len(rs) > 1

--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -5,13 +5,12 @@ from tkinter import Tk
 
 from .gui.bb_gui import BBGUIManager
 from .gui.bb_context import BBContext
+from .gui.sp_context import SPContext
 from ..data.MetaDataItem import MetaDataItem
 from ..signals import CancelSignal
 from .GUIExceptions import ManualTaggingAbortedException
 
-
-from .gui.context import GUIContext
-from .gui.sp_gui import SPGUIManager
+from .gui.sp_gui import SPGUIManager, Section
 from ..data.BBFields import BBFields
 
 # Lets the user tag the file. Modifies MetaDataItem in place
@@ -56,12 +55,10 @@ def split_file(file_loc, mdi:MetaDataItem):
 
     while True:
         try:
-            context = GUIContext(file_loc)
-            context.enum_tags = mdi.enum_tags
+            context = SPContext(file_loc)
+            context.initial_enum_tags = mdi.enum_tags
             gui = SPGUIManager(context)
             rs = gui.start()
-
-            mdi.enum_tags = context.enum_tags
 
             if len(rs) == 0:
                 raise CancelSignal("No sections of the video are of interest")
@@ -69,15 +66,15 @@ def split_file(file_loc, mdi:MetaDataItem):
             split_vid = len(rs) > 1
 
             ret = []
-            for i, vid_range in enumerate(rs):
+            for i, sec in enumerate(rs):
                 if i == 0:
                     m = mdi
                 else:
                     m = mdi.clone()
 
-                start, end = vid_range
-                m.start_i = start
-                m.end_i = end
+                m.start_i = sec.start
+                m.end_i = sec.end
+                m.enum_tags = sec.enum_tags
                 m.is_split_url = split_vid
 
                 ret.append(m)

--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -61,7 +61,7 @@ def split_file(file_loc, mdi:MetaDataItem):
             rs = gui.start()
 
             if len(rs) == 0:
-                mdi.enum_tags = gui.mode_handlers[0].sm.get_first_enum_tags()
+                mdi.enum_tags = gui.mode_handlers[0].sm.get_all_used_tags()
                 raise CancelSignal("No sections of the video are of interest")
 
             split_vid = len(rs) > 1

--- a/src/gui_tool/gui/bb_context.py
+++ b/src/gui_tool/gui/bb_context.py
@@ -6,6 +6,7 @@ class BBContext(GUIContext):
         super(BBContext, self).__init__(file_loc, start_index, end_index)
         self.bbox_fields = bbox_fields
         self.additional_tags = {}
+        self.enum_tags = []
 
     def set_bbox_fields_from_list(self, fields: List):
         self.bbox_fields = fields

--- a/src/gui_tool/gui/bb_gui.py
+++ b/src/gui_tool/gui/bb_gui.py
@@ -40,7 +40,7 @@ SELECTION_MODE_INSTRUCTIONS = [
         "Pressing n the first time will mark the video as not dashcam"],
     ["t", "Opens window for user customizable key-value tags"],
     ["v", "Opens window for user customizable enum tags"],
-    ["l", "Mark current frame as a accident location"],
+    ["l", "Mark accident location"],
 ]
 
 BB_CLASS_DEFAULT_OPTIONS = [

--- a/src/gui_tool/gui/context.py
+++ b/src/gui_tool/gui/context.py
@@ -10,7 +10,6 @@ class GUIContext(object):
         self.file_width = self.vcm.get_width()
 
         self.is_dashcam = True
-        self.enum_tags = []
 
     def mark_is_dashcam(self, is_dashcam: bool):
         self.marked = True

--- a/src/gui_tool/gui/sp_context.py
+++ b/src/gui_tool/gui/sp_context.py
@@ -1,0 +1,19 @@
+from .context import GUIContext
+from typing import List
+
+class SPContext(GUIContext):
+    def __init__(self, file_loc: str, start_index=None, end_index=None):
+        super(SPContext, self).__init__(file_loc, start_index, end_index)
+        self.initial_enum_tags = []
+
+    def set_bbox_fields_from_list(self, fields: List):
+        self.bbox_fields = fields
+
+    def get_bbox_fields(self):
+        return self.bbox_fields
+
+    def get_bbox_fields_as_list(self):
+        return self.bbox_fields
+
+    def set_additional_tags(self, tags):
+        self.additional_tags = tags

--- a/src/gui_tool/gui/sp_gui.py
+++ b/src/gui_tool/gui/sp_gui.py
@@ -437,7 +437,9 @@ class SplitManager(object):
                 ret.add(tag)
         return len(ret)
 
-
+    # Hotfix
+    def get_first_enum_tags(self):
+        return self.secs[0].enum_tags
 
 
 

--- a/src/gui_tool/gui/sp_gui.py
+++ b/src/gui_tool/gui/sp_gui.py
@@ -1,9 +1,11 @@
-from .context import GUIContext
+from __future__ import annotations
+from .sp_context import SPContext
 from ..utils.key_mapper import KeyMapper
 from .general_gui import VideoPlayerGUIManager
 from .gui_mode import InternalMode
 import cv2
 from .tinker_subuis.multiselect_popup import MultiSelectPopup
+from typing import List
 
 SP_MODE_INSTRUCTIONS = [
     ["x", "Split at the current frame exclusively", "Split is exclusive (current frame is gone)"],
@@ -11,7 +13,11 @@ SP_MODE_INSTRUCTIONS = [
     ["t", "Toggle the current section for deletion", "If deleted, this section will be ignored for the rest of the pipeline"],
     ["q", "Jump to previous split"],
     ["e", "Jump to next split"],
+    ["v", "Set enum tags for the CURRENT section"],
+    ["r*2", "reset enum tags the CURRENT section"],
 ]
+
+DEBUG_MODE = False
 
 class SPGUIManager(VideoPlayerGUIManager):
     WINDOW_NAME = 'splitter'
@@ -22,17 +28,17 @@ class SPGUIManager(VideoPlayerGUIManager):
     LOG_START_X = 250
     IMG_STARTING_Y = LOG_LINE_HEIGHT * LOG_LINES + LOG_LINE_MARGIN * (LOG_LINES + 1) + 3
 
-    def __init__(self, context: GUIContext):
+    def __init__(self, context: SPContext):
         super(SPGUIManager, self).__init__(context,
            [
                SPMode(self, context)
            ]
         )
 
-    def start(self):
+    def start(self) -> List[Section]:
         super(SPGUIManager, self).start()
-        active_ranges = self.mode_handlers[0].sm.get_all_active_ranges()
-        return active_ranges
+        active_sections = self.mode_handlers[0].sm.get_all_active_sections()
+        return active_sections
 
 
     def modify_frame(self, frame, frame_index):
@@ -46,12 +52,12 @@ class SectionStatus(object):
     DELETED = "DELETED"
 
 class SPMode(InternalMode):
-    def __init__(self, parent: SPGUIManager, context: GUIContext):
+    def __init__(self, parent: SPGUIManager, context: SPContext):
         super().__init__(parent, SP_MODE_INSTRUCTIONS)
         self.splits = []
         self.section_statuses = []
 
-        self.sm = SplitManager(self, context.vcm.get_frames_count())
+        self.sm = SplitManager(self, context.vcm.get_frames_count(), context.initial_enum_tags.copy())
 
     def handle_click(self, event, x, y, flags, param):
         pass
@@ -61,8 +67,6 @@ class SPMode(InternalMode):
         sm = self.sm
         i = vcm.get_frame_index()
 
-        # if key_mapper.consume("r"):
-        #     sm.reset()
         if key_mapper.consume("x"):
             sm.split(i)
         elif key_mapper.consume("z"):
@@ -70,34 +74,46 @@ class SPMode(InternalMode):
         elif key_mapper.consume("t"):
             sm.toggle_section(i)
         elif key_mapper.consume("q"):
-            p_loc = sm.find_previous_split(i)
+            p_loc = sm.find_previous_split_location(i)
             if p_loc is not None:
                 self.par.vcm.start_from(p_loc)
             else:
                 self.error("Can't jump: No previous split exists")
         elif key_mapper.consume("e"):
-            n_loc = sm.find_next_split(i)
+            n_loc = sm.find_next_split_location(i)
             if n_loc is not None:
                 self.par.vcm.start_from(n_loc)
             else:
-                self.error("Can't jump: No previous split exists")
+                self.error("Can't jump: No next split exists")
         elif key_mapper.consume("v"):
-            window = MultiSelectPopup("Select custom enum tags", "video_enum_tags", self.par.context.enum_tags)
-            enum_tags = window.run()
-            if enum_tags is not None:
-                self.log("Updated from {0}".format(self.par.context.enum_tags))
-                self.log("Now: {0}".format(enum_tags))
-                self.par.context.enum_tags = enum_tags
-                self.log("Remember to commit any new tags!")
+            curr_tags = sm.get_enum_tags_at(i)
+            if curr_tags is None:
+                self.error("Cannot set tags on a split")
             else:
-                self.log("Enum tag update cancelled")
+                window = MultiSelectPopup("Select custom enum tags", "video_enum_tags", curr_tags)
+                enum_tags = window.run()
+                if enum_tags is not None:
+                    self.log("Updated from {0}".format(curr_tags))
+                    self.log("Now: {0}".format(enum_tags))
+                    self.sm.set_enum_tags_at(i, enum_tags)
+                    self.log("Remember to commit any new tags!")
+                else:
+                    self.log("Enum tag update cancelled")
+        elif key_mapper.consume(("r", "r")):
+            curr_tags = sm.get_enum_tags_at(i)
+            if curr_tags is None:
+                self.error("Cannot reset tags on a split")
+            else:
+                self.sm.set_enum_tags_at(i, [])
+                self.log("Removing all enum tags (previously {0})".format(curr_tags))
 
     def get_state_message(self):
         return [
             "Split Mode",
-            "{0} Splits".format(self.sm.get_n_splits()),
             "{0}/{1} Deleted".format(self.sm.get_n_deleted(), self.sm.get_n_sections()),
             "{0:.1f}% Deleted".format(self.sm.get_prop_deleted() * 100.0),
+            "{0} Uq. Tag sets".format(self.sm.get_n_unique_tag_sets()),
+            "{0} Total tags".format(self.sm.get_n_total_tags()),
         ]
 
     def modify_frame(self, frame, i):
@@ -119,112 +135,143 @@ class DisplayParams(object):
         self.x_loc = x_loc
         self.formatter = formatter
 
+class Section(object):
+    def __init__(self, start: int, end: int, status: str, enum_tags: List[str]):
+        self.start = start
+        self.end = end
+        self.status = status
+        self.enum_tags = enum_tags
+
+    def split_failure_msg(self, loc):
+        if abs(loc-self.start)<=0:
+            return "Split location too close to a previous split at {0}".format(self.start-1)
+        if abs(loc-self.end)<=1:
+            return "Split location too close to next split ar {0}".format(self.end)
+        return None
+
+    def split(self, loc) -> (Section, Section):
+        s1 = Section(self.start, loc, self.status, self.enum_tags.copy())
+        s2 = Section(loc+1, self.end, self.status, self.enum_tags.copy())
+        return s1, s2
+
+    @classmethod
+    def join_failure_msg(cls, s1: Section, s2: Section):
+        if s1.enum_tags != s2.enum_tags:
+            return "The enum tags of the 2 sections are not equal"
+        if s1.status != s2.status:
+            return "The status of the 2 sections are not equal"
+        if s1.start > s2.start:
+            s1, s2 = s2, s1
+        if s1.end + 1 != s2.start:
+            return "Internal error. 2 sections are not connected"
+        return None
+
+    @classmethod
+    def join(cls, s1: Section, s2: Section) -> Section:
+        return Section(min(s1.start, s2.start), max(s1.end, s2.end), s1.status, s1.enum_tags.copy())
+
+    def toggle_status(self):
+        if self.status == SectionStatus.ACTIVE:
+            self.status = SectionStatus.DELETED
+        else:
+            self.status = SectionStatus.ACTIVE
+
 class SplitManager(object):
     # Color in BGR
     SPLIT_DISPLAY =   {"fontFace": cv2.FONT_HERSHEY_SIMPLEX, "fontScale": 1, "thickness": 2, "color": (153, 51, 51)}
     DELETED_DISPLAY = {"fontFace": cv2.FONT_HERSHEY_SIMPLEX, "fontScale": 1, "thickness": 2, "color": (10, 10, 204)}
     ACTIVE_DISPLAY =  {"fontFace": cv2.FONT_HERSHEY_SIMPLEX, "fontScale": 1, "thickness": 2, "color": (51, 204, 51)}
+    ENUM_DISPLAY =    {"fontFace": cv2.FONT_HERSHEY_SIMPLEX, "fontScale": 0.5, "thickness": 1, "color": (150, 150, 150)}
     CURRENT_LOC_COLOR = (51, 153, 255)
 
-    def __init__(self, parent, frame_count):
+    def __init__(self, parent: SPMode, frame_count: int, initial_enum_tags: List[str]):
         self.par = parent
         self.frame_count = frame_count
-        self.splits = []
-        self.section_statuses = [SectionStatus.ACTIVE]
-
-    def reset(self):
-        self.splits = []
-        self.section_statuses = [SectionStatus.ACTIVE]
+        if initial_enum_tags is None:
+            initial_enum_tags = []
+        self.secs = [Section(0, self.frame_count, SectionStatus.ACTIVE, initial_enum_tags)]
 
     def split(self, loc):
-        if loc == 0 or loc == self.frame_count-1:
+        if loc == 0 or loc == self.frame_count - 1:
             return self.par.error("Cannot split at endpoints")
+
         info = self.__find(loc)
         if info.kind == SMLocInfo.SPLIT:
             return self.par.error("Split already exists at {0}".format(loc))
 
-        if self.section_statuses[info.ii] == SectionStatus.DELETED:
+        ii = info.ii
+        if self.secs[ii].status == SectionStatus.DELETED:
             self.par.warn("Splitting on a deleted section. Both sides will be deleted")
-        p_loc, n_loc = self.find_previous_split(loc), self.find_next_split(loc)
-        if p_loc is not None:
-            if loc - p_loc == 1:
-                return self.par.error("Cannot split right next to another split")
-            if loc - p_loc <= 5:
-                self.par.warn("Splitting very close to an existing previous split ({0} away)".format(loc - p_loc))
-        if n_loc is not None:
-            if n_loc - loc == 1:
-                return self.par.error("Cannot split right next to another split")
-            if n_loc - loc <= 5:
-                self.par.warn("Splitting very close to an existing following split ({0} away)".format(n_loc - loc))
 
-        self.splits.insert(info.ii, loc)
-        self.section_statuses.insert(info.ii, self.section_statuses[info.ii])
+        fail_msg = self.secs[ii].split_failure_msg(loc)
+        if fail_msg is not None:
+            return self.par.error("Splitting failed: {0}".format(fail_msg))
+
+        s1, s2 = self.secs[info.ii].split(loc)
+        self.secs[ii] = s1
+        self.secs.insert(ii+1, s2)
         self.par.log("New split made at {0}".format(loc))
 
     def erase_split(self, loc):
+        if loc == 0 or loc == self.frame_count - 1:
+            return self.par.error("Nothing to join at video endpoints")
+
         info = self.__find(loc)
         if info.kind != SMLocInfo.SPLIT:
             return self.par.error("Frame {0} is not the location of a split".format(loc))
         ii = info.ii
-        if self.section_statuses[ii] != self.section_statuses[ii+1]:
-            return self.par.error("Both sides of the split must be in the same state ({0} != {1})".format(
-                self.section_statuses[ii], self.section_statuses[ii+1]
-            ))
-        del self.splits[ii]
-        del self.section_statuses[ii]
+
+        fail_msg = Section.join_failure_msg(self.secs[ii], self.secs[ii+1])
+        if fail_msg is not None:
+            return self.par.error("Joining failed: {0}".format(fail_msg))
+
+        s = Section.join(self.secs[ii], self.secs[ii+1])
+        self.secs[ii] = s
+        del self.secs[ii+1]
         self.par.log("Split at {0} was removed".format(loc))
 
     def toggle_section(self, loc):
         info = self.__find(loc)
-        if info.kind != SMLocInfo.SECTION:
+        if loc != 0 and info.kind != SMLocInfo.SECTION:
             return self.par.error("Frame {0} is a split".format(loc))
-        if self.section_statuses[info.ii] == SectionStatus.ACTIVE:
-            self.section_statuses[info.ii] = SectionStatus.DELETED
-        else:
-            self.section_statuses[info.ii] = SectionStatus.ACTIVE
-        self.par.log("Current section state was toggled to {0}".format(self.section_statuses[info.ii]))
+        self.secs[info.ii].toggle_status()
+        self.par.log("Current section state was toggled to {0}".format(self.secs[info.ii].status))
 
-
-    def __find(self, loc):
+    def __find(self, loc) -> SMLocInfo:
         ii = None
         kind = None
-        if len(self.splits) == 0:
-            ii = 0
-            kind = SMLocInfo.SECTION
-        elif loc > self.splits[-1]:
-            ii = len(self.splits)
-            kind = SMLocInfo.SECTION
-        else:
-            for i, s in enumerate(self.splits):
-                if s == loc:
-                    ii = i
-                    kind = SMLocInfo.SPLIT
-                    break
-                if s > loc:
-                    ii = i
-                    kind = SMLocInfo.SECTION
-                    break
+        if loc == 0:
+            return SMLocInfo(loc, SMLocInfo.SPLIT, 0)
+        for i, s in enumerate(self.secs):
+            if s.end == loc:
+                ii = i
+                kind = SMLocInfo.SPLIT
+                break
+            if s.start <= loc < s.end:
+                ii = i
+                kind = SMLocInfo.SECTION
+                break
 
         return SMLocInfo(loc, kind, ii)
 
-    def find_previous_split(self, loc):
-        for split in reversed(self.splits):
-            if split < loc:
-                return split
+    def find_previous_split_location(self, loc) -> int:
+        for sec in reversed(self.secs):
+            if sec.end < loc:
+                return sec.end
         return None
 
-    def find_next_split(self, loc):
-        for split in self.splits:
-            if split > loc:
-                return split
+    def find_next_split_location(self, loc) -> int:
+        for sec in self.secs[:-1]:
+            if sec.end > loc:
+                return sec.end
         return None
 
     def modify_frame(self, frame, loc, width, height):
-        def get_location(text, center_pct):
+        def get_location(text, center_pct, formatter):
             textsize = cv2.getTextSize(text,
-                    self.SPLIT_DISPLAY["fontFace"],
-                    self.SPLIT_DISPLAY["fontScale"],
-                    self.SPLIT_DISPLAY["thickness"])[0]
+                    formatter["fontFace"],
+                    formatter["fontScale"],
+                    formatter["thickness"])[0]
             target_loc = (width - 10) * center_pct + 5
             return max(
                 min(
@@ -239,19 +286,20 @@ class SplitManager(object):
 
         def build_minimap():
             ratio = (width-20.0)/(self.frame_count-1)
-            split_x = [int(s*ratio) + 10 for s in self.splits]
-            ext_split_x = [int(s*ratio) + 10 for s in [0] + self.splits + [self.frame_count-1]]
-            current_x = int(loc*ratio) + 10
-            for start, end, status in zip(ext_split_x[:-1], ext_split_x[1:], self.section_statuses):
-                color = f_by_status(status)["color"]
-                cv2.rectangle(frame, (start, 10), (end, 20), color, thickness=-1)
-            on_split = False
-            for split, rs in zip(split_x, self.splits):
-                cv2.rectangle(frame, (split-1, 8), (split+1, 22), self.SPLIT_DISPLAY["color"], thickness=-1)
-                if split == current_x: # Having current ontop of split when it is not a split is misleading
-                    if rs>loc:
+            def t(val):
+                return max(10, min(width-10, int(val*ratio) + 10))
+            current_x = t(loc)
+            for sec in self.secs:
+                color = f_by_status(sec.status)["color"]
+                cv2.rectangle(frame, (t(sec.start-1), 10), (t(sec.end), 20), color, thickness=-1)
+            on_split = loc == 0
+            for sec in self.secs[:-1]:
+                mark_loc = t(sec.end)
+                cv2.rectangle(frame, (mark_loc-1, 8), (mark_loc+1, 22), self.SPLIT_DISPLAY["color"], thickness=-1)
+                if mark_loc == current_x:  # Having current ontop of split when it is not a split is misleading
+                    if sec.end>loc:
                         current_x -= 1
-                    elif rs < loc:
+                    elif sec.end < loc:
                         current_x += 1
                     else:
                         on_split = True
@@ -266,90 +314,128 @@ class SplitManager(object):
         kind = info.kind
 
         to_display = []
-        if kind == SMLocInfo.SECTION:
+        if loc == 0 or kind == SMLocInfo.SECTION:
             # Prev text
+            sec = self.secs[ii]
             if ii != 0:
-                to_display.append(DisplayParams("< " + str(loc - self.splits[ii-1]),
+                to_display.append(DisplayParams("< " + str(loc - sec.start+1),
                                                 0, 0.0, self.SPLIT_DISPLAY))
-                to_display.append(DisplayParams("At " + str(self.splits[ii-1]),
+                to_display.append(DisplayParams("At " + str(sec.start+1),
                                                 1, 0.0, self.SPLIT_DISPLAY))
 
 
             # Current text
-            f = f_by_status(self.section_statuses[ii])
             to_display.append(DisplayParams("Section {0}".format(ii+1),
-                                            0, 0.5, f))
+                                            0, 0.5, f_by_status(self.secs[ii].status)))
+            to_display.append(DisplayParams(str(self.secs[ii].enum_tags),
+                                            1, 0.5, self.ENUM_DISPLAY))
+
 
             # Next text
-            if ii != len(self.splits):
-                to_display.append(DisplayParams(str(self.splits[ii] - loc) + " >",
+            if ii <= len(self.secs)-2:
+                to_display.append(DisplayParams(str(sec.end - loc) + " >",
                                                 0, 1.0, self.SPLIT_DISPLAY))
-                to_display.append(DisplayParams("At " + str(self.splits[ii]),
+                to_display.append(DisplayParams("At " + str(sec.end),
                                                 1, 1.0, self.SPLIT_DISPLAY))
 
         elif kind == SMLocInfo.SPLIT:
             # Prev text
-            if ii != 0:
-                to_display.append(DisplayParams("< " + str(loc - self.splits[ii-1]),
+            if ii >= 1:
+                to_display.append(DisplayParams("< " + str(loc - self.secs[ii-1].end),
                                                 0, 0.0, self.SPLIT_DISPLAY))
-                to_display.append(DisplayParams( "At " + str(self.splits[ii-1]),
+                to_display.append(DisplayParams( "At " + str(self.secs[ii-1].end),
                                                 1, 0.0, self.SPLIT_DISPLAY))
 
             # Current text
-            to_display.append(DisplayParams("Split {0}".format(ii+1),
+            to_display.append(DisplayParams("Split {0}".format(ii),
                                             0, 0.5, self.SPLIT_DISPLAY))
 
             # Next text
-            if ii != len(self.splits) - 1:
-                to_display.append(DisplayParams(str(self.splits[ii+1] - loc) + " >",
+            if ii <= len(self.secs) - 3:
+                to_display.append(DisplayParams(str(self.secs[ii+1].end - loc) + " >",
                                                 0, 1.0, self.SPLIT_DISPLAY))
-                to_display.append(DisplayParams("At " + str(self.splits[ii+1]),
+                to_display.append(DisplayParams("At " + str(self.secs[ii+1].end),
                                                 1, 1.0, self.SPLIT_DISPLAY))
 
         for p in to_display:
-            cv2.putText(frame, p.text, (get_location(p.text, p.x_loc), (p.line_num+1) * 30 + 25), **p.formatter)
+            if len(p.text) > 70:
+                p.text = p.text[:67] + "..."
+            cv2.putText(frame, p.text, (get_location(p.text, p.x_loc, p.formatter), (p.line_num+1) * 30 + 25), **p.formatter)
+
+        if DEBUG_MODE:
+            self.validate()
         return frame
 
 
-    def get_n_splits(self):
-        return len(self.splits)
+    def get_n_sections(self):
+        return len(self.secs)
 
     def get_n_deleted(self):
-        return sum([x == SectionStatus.DELETED for x in self.section_statuses])
+        return sum([x.status == SectionStatus.DELETED for x in self.secs])
 
-    def get_n_sections(self):
-        return len(self.section_statuses)
-
-    def get_all_active_ranges(self):
-        splits = [-1] + self.splits + [self.frame_count]
-        active_ranges = []
-        for i in range(len(self.section_statuses)):
-            if self.section_statuses[i] == SectionStatus.DELETED:
+    def get_all_active_sections(self) -> List[Section]:
+        active_sections = []
+        for sec in self.secs:
+            if sec.status == SectionStatus.DELETED:
                 continue
-            start = splits[i]
-            end = splits[i+1]
-
-            # Start and end frames will be removed
-            if not (start+1 < end):
-                continue
-
-            active_ranges.append((start+1, end))
-        return active_ranges
+            active_sections.append(sec)
+        return active_sections
 
     def get_prop_deleted(self):
-        deleted_frames = len(self.splits)
-        splits = [-1] + self.splits + [self.frame_count]
-        for i in range(len(self.section_statuses)):
-            if self.section_statuses[i] == SectionStatus.DELETED:
-                deleted_frames += splits[i+1] - splits[i] - 1
+        deleted_frames = len(self.secs)-1 # Endpoints are gone
+        for sec in self.secs:
+            if sec.status == SectionStatus.DELETED:
+                deleted_frames += sec.end - sec.start
 
         return deleted_frames * 1.0 / self.frame_count
 
+    # Check consistency
+    def validate(self):
+        for s1, s2 in zip(self.secs[:-1], self.secs[1:]):
+            if s1.end + 1 != s2.start:
+                raise ValueError("Connection check failed")
+
+        if self.secs[0].start != 0:
+            raise ValueError("Start changed")
+
+        if self.secs[-1].end != self.frame_count:
+            raise ValueError("End changed")
+
+        for sec in self.secs:
+            if not (sec.start < sec.end):
+                raise ValueError("Invalid section start and end locations")
+
+        if sum([sec.end-sec.start+1 for sec in self.secs]) != self.frame_count+1:
+            raise ValueError("Total number of frames is not correct")
+
+        if len(set([id(sec.enum_tags) for sec in self.secs])) != len(self.secs):
+            raise ValueError("Two sections are using the same enum tag array")
+
+    def get_enum_tags_at(self, loc) -> List[str]:
+        info = self.__find(loc)
+        if loc != 0 and info.kind == SMLocInfo.SPLIT:
+            return None
+        return self.secs[info.ii].enum_tags.copy()
+
+    def set_enum_tags_at(self, loc, enum_tags):
+        info = self.__find(loc)
+        if loc != 0 and info.kind == SMLocInfo.SPLIT:
+            return
+        self.secs[info.ii].enum_tags = enum_tags.copy()
+
+    def get_n_unique_tag_sets(self) -> int:
+        ret = []
+        for sec in self.secs:
+            ret.append(tuple(sec.enum_tags))
+        return len(set(ret))
 
 
-
-
-
+    def get_n_total_tags(self) -> int:
+        ret = set()
+        for sec in self.secs:
+            for tag in sec.enum_tags:
+                ret.add(tag)
+        return len(ret)
 
 
 

--- a/src/gui_tool/gui/sp_gui.py
+++ b/src/gui_tool/gui/sp_gui.py
@@ -438,8 +438,13 @@ class SplitManager(object):
         return len(ret)
 
     # Hotfix
-    def get_first_enum_tags(self):
-        return self.secs[0].enum_tags
+    def get_all_used_tags(self):
+        ret = []
+        for sec in self.secs:
+            for tag in sec.enum_tags:
+                if tag not in ret:
+                    ret.append(tag)
+        return ret
 
 
 


### PR DESCRIPTION
Changed how sections were handled internally (and thus had to completely change sp_gui.py)

When splitting a section into 2, the enum tags of both sections will be equal to that of the original.
Cannot join sections if they have different enum tags

There are 2 new status messages: "Uq. Tag sets" is the number of unique combinations of tags for all sections, and "Total tags" is the number of tags that are set on ANY section

![image](https://user-images.githubusercontent.com/36652220/99190855-44b6c000-2726-11eb-84a8-8ebf426c04fe.png)
