### PR TITLE
Sections that are not of interest are still passed on. Splitter doesn't use CancelSignal

### DIFF
--- a/src/gui_tool/entry.py
+++ b/src/gui_tool/entry.py
@@ -10,7 +10,7 @@ from ..data.MetaDataItem import MetaDataItem
 from ..signals import CancelSignal
 from .GUIExceptions import ManualTaggingAbortedException
 
-from .gui.sp_gui import SPGUIManager, Section
+from .gui.sp_gui import SPGUIManager, Section, SectionStatus
 from ..data.BBFields import BBFields
 
 # Lets the user tag the file. Modifies MetaDataItem in place
@@ -60,10 +60,6 @@ def split_file(file_loc, mdi:MetaDataItem):
             gui = SPGUIManager(context)
             rs = gui.start()
 
-            if len(rs) == 0:
-                mdi.enum_tags = gui.mode_handlers[0].sm.get_all_used_tags()
-                raise CancelSignal("No sections of the video are of interest")
-
             split_vid = len(rs) > 1
 
             ret = []
@@ -77,6 +73,7 @@ def split_file(file_loc, mdi:MetaDataItem):
                 m.end_i = sec.end
                 m.enum_tags = sec.enum_tags
                 m.is_split_url = split_vid
+                m.is_cancelled = not (sec.status == SectionStatus.ACTIVE)
 
                 ret.append(m)
             return ret

--- a/src/gui_tool/gui/sp_gui.py
+++ b/src/gui_tool/gui/sp_gui.py
@@ -37,7 +37,7 @@ class SPGUIManager(VideoPlayerGUIManager):
 
     def start(self) -> List[Section]:
         super(SPGUIManager, self).start()
-        active_sections = self.mode_handlers[0].sm.get_all_active_sections()
+        active_sections = self.mode_handlers[0].sm.get_all_sections()
         return active_sections
 
 
@@ -373,13 +373,8 @@ class SplitManager(object):
     def get_n_deleted(self):
         return sum([x.status == SectionStatus.DELETED for x in self.secs])
 
-    def get_all_active_sections(self) -> List[Section]:
-        active_sections = []
-        for sec in self.secs:
-            if sec.status == SectionStatus.DELETED:
-                continue
-            active_sections.append(sec)
-        return active_sections
+    def get_all_sections(self) -> List[Section]:
+        return self.secs
 
     def get_prop_deleted(self):
         deleted_frames = len(self.secs)-1 # Endpoints are gone

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -107,7 +107,12 @@ def run_recur(source_executor, item, dataUpdater):
         items = [items]
 
     for next_item in items:
-        run_recur(source_executor.get_next(), next_item, dataUpdater)
+        metadata = iExecutor.get_metadata(next_item)
+        if metadata.is_cancelled == True:
+            metadata.add_tag('state', 'processed')
+            dataUpdater.safe_run(metadata)
+        else:
+            run_recur(source_executor.get_next(), next_item, dataUpdater)
 
 if __name__ == "__main__":
     main()

--- a/test/testAdministrator.py
+++ b/test/testAdministrator.py
@@ -6,6 +6,7 @@ from multiprocessing import Queue
 from queue import Empty as EmptyException
 from src.PipelineConfiguration import PipelineConfiguration
 from src.data.MetaDataItem import MetaDataItem
+from collections import defaultdict
 
 events = Queue()
 
@@ -17,7 +18,7 @@ class TestExecutor(iExecutor):
     def run(self, obj):
         print(f"run {self.event_num}")
         events.put(self.event_num)
-        return MetaDataItem()
+        return MetaDataItem(title=None, url=None, download_src=None)
 
 
 class MultipleReturnExecutor(iExecutor):

--- a/test/testAdministrator.py
+++ b/test/testAdministrator.py
@@ -5,6 +5,7 @@ from src.executor.iExecutor import iExecutor
 from multiprocessing import Queue
 from queue import Empty as EmptyException
 from src.PipelineConfiguration import PipelineConfiguration
+from src.data.MetaDataItem import MetaDataItem
 
 events = Queue()
 
@@ -16,7 +17,7 @@ class TestExecutor(iExecutor):
     def run(self, obj):
         print(f"run {self.event_num}")
         events.put(self.event_num)
-        return 1
+        return MetaDataItem()
 
 
 class MultipleReturnExecutor(iExecutor):

--- a/test/testAdministrator.py
+++ b/test/testAdministrator.py
@@ -6,7 +6,6 @@ from multiprocessing import Queue
 from queue import Empty as EmptyException
 from src.PipelineConfiguration import PipelineConfiguration
 from src.data.MetaDataItem import MetaDataItem
-from collections import defaultdict
 
 events = Queue()
 
@@ -27,7 +26,7 @@ class MultipleReturnExecutor(iExecutor):
         super().__init__(parents)
 
     def run(self, obj):
-        return [x for x in range(self.iters)]
+        return [MetaDataItem(title=None, url=None, download_src=None) for _ in range(self.iters)]
 
 
 class ExceptionExecutor(iExecutor):


### PR DESCRIPTION
Right now, if a section is disabled in the splitter gui, it is not passed on. This means that if you set enum tags on it, it doesn't get applied. Which kinda ruins half the point of the enum tags, which is to go back on the parts we dropped for the time being

This makes it so that dataUpdater is called for ALL sections in the splitter, including the disabled ones